### PR TITLE
Upgrade to SDRPlay v3 & Fix build errors

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -191,7 +191,7 @@ jobs:
           python-version: "3.7"
           architecture: ${{ matrix.architecture }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: win-${{ matrix.architecture }}
           path: dist

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -199,6 +199,7 @@ jobs:
 
       - name: Check native backends
         run: |
+          export BLADERF_API_VERSION=2.5
           git clone --depth 1 https://github.com/jopohl/urh && cd urh
           mkdir src/urh/dev/native/lib/shared
           cp -r ../dist/* src/urh/dev/native/lib/shared/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,6 +86,7 @@ jobs:
           echo "* AirSpy: `git show --format='%h (%s, %as)' --no-patch`" >> $GITHUB_WORKSPACE/release_notes.md
 
       - name: BladeRF download
+        if: ${{ matrix.architecture == 'x64' }}
         run: |
           wget -nv -O bladerf.exe -nv https://github.com/Nuand/bladeRF/releases/download/2024.05/bladeRF-win-installer-2024.05.exe
           innoextract bladerf.exe -d bladerf

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -205,7 +205,7 @@ jobs:
           python --version
           python -m pip install -r data/requirements.txt
           python setup.py build_ext --inplace
-          python -m pip install .
+          python -m pip install . --no-build-isolation
           python data/check_native_backends.py
 
       - name: Create zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: BladeRF download
         run: |
-          wget -nv -O bladerf.exe -nv https://www.nuand.com/windows_installers/bladeRF-win-installer-2021.03.exe
+          wget -nv -O bladerf.exe -nv https://github.com/Nuand/bladeRF/releases/download/2024.05/bladeRF-win-installer-2024.05.exe
           innoextract bladerf.exe -d bladerf
           cp bladerf/app/include/* dist/include
           cp bladerf/app/$ARCH/* dist

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -187,9 +187,9 @@ jobs:
           rm dist/*.exe
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.7"
+          python-version: "3.9"
           architecture: ${{ matrix.architecture }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -204,6 +204,7 @@ jobs:
           mkdir src/urh/dev/native/lib/shared
           cp -r ../dist/* src/urh/dev/native/lib/shared/
           python --version
+          python -m pip install wheel
           python -m pip install -r data/requirements.txt
           python setup.py build_ext --inplace
           python -m pip install . --no-build-isolation

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [windows-latest]
         architecture: [x86, x64]
     env:
       ARCH: ${{ matrix.architecture }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: HackRF build
         run: |
-          git clone --depth 1 https://github.com/greatscottgadgets/hackrf
+          git clone --branch v2024.02.1 --depth 1 https://github.com/greatscottgadgets/hackrf
           mkdir hackrf/host/build && cd hackrf/host/build
           cmake -A $CMAKE_ARCH -DCMAKE_BUILD_TYPE=Release\
                 -DLIBUSB_LIBRARIES=$GITHUB_WORKSPACE/libusb/VS2019/MS$ARCH_NUM/Release/lib/libusb-1.0.lib \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -170,7 +170,7 @@ jobs:
       - name: UHD download
         run: |
           mkdir uhd && cd uhd
-          wget -nv -O uhd.exe https://files.ettus.com/binaries/uhd/latest_release/4.1.0.5/Windows-10-x64/uhd_4.1.0.5-release_Win${ARCH}_VS2019.exe
+          wget -nv -O uhd.exe https://files.ettus.com/binaries/uhd/uhd_004.001.000.005-release/4.1.0.5/Windows-10-x64/uhd_4.1.0.5-release_Win${ARCH}_VS2019.exe
           7z x uhd.exe
           cp bin/uhd.dll ../dist
           cp lib/uhd.lib ../dist

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,7 +122,6 @@ jobs:
           cmake --install . --prefix $GITHUB_WORKSPACE/dist --config Release
           echo "* LimeSuite: `git show --format='%h (%s, %as)' --no-patch`" >> $GITHUB_WORKSPACE/release_notes.md
 
-
       - name: RTL-SDR build
         run: |
           git clone --depth 1 https://github.com/osmocom/rtl-sdr
@@ -162,12 +161,11 @@ jobs:
       - name: SDRPlay download
         run: |
           mkdir sdrplay && cd sdrplay
-          wget -nv -O sdrplay.exe https://www.sdrplay.com/software/SDRplay_RSP_API-Windows-2.13.1.exe
+          wget -nv -O sdrplay.exe https://www.sdrplay.com/software/SDRplay_RSP_API-Windows-3.15.exe
           innoextract sdrplay.exe
           cp app/API/inc/* ../dist/include
-          mv ../dist/include/mir_sdr.h ../dist/include/mirsdrapi-rsp.h
           cp app/API/$ARCH/* ../dist
-          echo "* SDRPlay: 2.13.1" >> $GITHUB_WORKSPACE/release_notes.md
+          echo "* SDRPlay: 3.15" >> $GITHUB_WORKSPACE/release_notes.md
 
       - name: UHD download
         run: |


### PR DESCRIPTION
See https://github.com/jopohl/urh/pull/1188

The installer at `https://www.nuand.com/windows_installers/bladeRF-win-installer-2021.03.exe` is no longer available, so I tried switching to a newer version; however, the versions provided on GitHub no longer support Windows x86.

In addition, python 3.8+ won't load dll from `src/urh/dev/native/lib/shared/` directory, causing errors: (https://github.com/stevenjoezhang/sdrbuild/actions/runs/18632979312/job/53120282231)
```
AirSpy:    FAILURE (DLL load failed while importing airspy: The specified module could not be found.)
BladeRF:   FAILURE (No module named 'urh.dev.native.lib.bladerf')
HackRF:    FAILURE (DLL load failed while importing hackrf: The specified module could not be found.)
RTLSDR:    FAILURE (DLL load failed while importing rtlsdr: The specified module could not be found.)
LimeSDR:   FAILURE (DLL load failed while importing limesdr: The specified module could not be found.)
PlutoSDR:  FAILURE (DLL load failed while importing plutosdr: The specified module could not be found.)
SDRPlay:   FAILURE (No module named 'urh.dev.native.lib.sdrplay')
USRP:      FAILURE (DLL load failed while importing usrp: The specified module could not be found.)
```

I believe all other issues have been resolved.